### PR TITLE
fix(widgets): add mobile font-size, change mobile padding

### DIFF
--- a/src/shared/ui/accordion.tsx
+++ b/src/shared/ui/accordion.tsx
@@ -17,7 +17,7 @@ export function Accordion({ items }: AccordionProps) {
             key={question}
             className="group cursor-pointer rounded-xl border border-accent-orange-light hover:border-accent-orange"
           >
-            <summary className="mb-2 flex list-none items-center justify-between p-6 text-lg font-semibold select-none">
+            <summary className="mb-2 flex list-none items-center justify-between p-6 text-sm font-semibold select-none xl:text-lg">
               {question}
               <AccordionArrowIcon className="group-open:rotate-180 [&>:first-child]:fill-accent-orange-light [&>:first-child]:hover:fill-accent-orange" />
             </summary>

--- a/src/widgets/faq/ui/faq.tsx
+++ b/src/widgets/faq/ui/faq.tsx
@@ -3,7 +3,7 @@ import { faqData } from "../model/meta";
 
 export function Faq() {
   return (
-    <div className="flex flex-col gap-32 px-20 py-10">
+    <div className="flex flex-col gap-32 px-5 py-10 xl:px-20">
       <hgroup className="flex flex-col items-center gap-4 text-lg">
         <Title>
           Вопросы<span className="text-accent-orange"> и ответы</span>


### PR DESCRIPTION
**Задача:** 

<img width="424" height="943" alt="Screenshot from 2025-10-06 14-39-30" src="https://github.com/user-attachments/assets/70e49f0e-6bc3-44d9-a9af-3bcc2833be13" />


**проект :**

<img width="448" height="479" alt="Screenshot from 2025-10-06 14-34-34" src="https://github.com/user-attachments/assets/2ad196d3-c333-45f9-9fa4-4053020f25a6" />
