### PR TITLE
fix(widgets): add leading for mobile hero title

### DIFF
--- a/src/widgets/hero/ui/hero.tsx
+++ b/src/widgets/hero/ui/hero.tsx
@@ -41,7 +41,7 @@ export function Hero() {
         )}
       >
         <div className="flex flex-col">
-          <Title className="text-inherit xl:max-w-[678px] xl:text-left">
+          <Title className="leading-[0.85] text-inherit xl:max-w-[678px] xl:text-left xl:leading-none">
             Волейбольная школа для&nbsp;
             <span className="text-accent-green">всех возрастов</span>
           </Title>


### PR DESCRIPTION
**TAsk :**

<img width="403" height="518" alt="Screenshot from 2025-10-06 14-54-31" src="https://github.com/user-attachments/assets/e6fbad00-b408-479c-8956-4396be72579a" />
<img width="405" height="241" alt="Screenshot from 2025-10-06 14-54-41" src="https://github.com/user-attachments/assets/760fc42f-24b4-4032-804e-ad9f7718e7e7" />


Проект:


<img width="382" height="644" alt="Screenshot from 2025-10-06 14-54-51" src="https://github.com/user-attachments/assets/0a19de80-31f3-4fa7-8506-268136703f25" />
