### PR TITLE
fix(widgets): change config of name input

### DIFF
--- a/src/widgets/contact-form/model/config.ts
+++ b/src/widgets/contact-form/model/config.ts
@@ -3,7 +3,7 @@ import { ContactFormModel } from "./types";
 
 export const formSchema = z.object({
   city: z.string(),
-  name: z.string().min(4, "Поле должно быть заполнено"),
+  name: z.string().min(2, "Поле должно быть заполнено"),
   phone: z
     .string()
     .regex(


### PR DESCRIPTION
Добавлена возможность именам из 2 смволов  быть валидными 

<img width="354" height="459" alt="Screenshot from 2025-11-05 23-10-15" src="https://github.com/user-attachments/assets/4756c244-c958-49fa-8ade-b7402b62d88e" />

исправлено :

<img width="491" height="397" alt="Screenshot from 2025-11-05 23-00-22" src="https://github.com/user-attachments/assets/ef18e583-e009-4116-99c4-a4097cb99602" />


<img width="491" height="397" alt="Screenshot from 2025-11-05 23-00-34" src="https://github.com/user-attachments/assets/c9c7f0dc-e6ca-48e6-9502-205f204f8a76" />

<img width="491" height="397" alt="Screenshot from 2025-11-05 23-01-26" src="https://github.com/user-attachments/assets/d4628964-4f7e-4b22-adee-0365e8f9bba4" />
