### PR TITLE
fix(widgets): advantages was centering

### DIFF
--- a/src/widgets/advantages/ui/advantages.tsx
+++ b/src/widgets/advantages/ui/advantages.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 
 export function Advantages() {
   return (
-    <section className="flex flex-col gap-12 px-10 py-[74px] text-center text-sm xl:flex-row xl:justify-between xl:gap-0 xl:px-20 xl:text-base">
+    <section className="flex flex-col items-center gap-12 px-10 py-[74px] text-center text-sm xl:flex-row xl:justify-between xl:gap-0 xl:px-20 xl:text-base">
       {advantagesData.map(({ title, imageSrc, description, alt }) => {
         return (
           <div


### PR DESCRIPTION
было 

<img width="334" height="490" alt="Screenshot from 2025-11-06 20-52-57" src="https://github.com/user-attachments/assets/ecf7cac9-a5a7-4023-bd17-bb3938bdf737" />

стало 

<img width="723" height="784" alt="Screenshot from 2025-11-06 20-57-31" src="https://github.com/user-attachments/assets/0ea8bae6-48ce-4ac7-8f18-a785933d0061" />