### PR TITLE
fix(shared): add-padding for mobile carousel button

### DIFF
--- a/src/shared/ui/carousel/carousel.tsx
+++ b/src/shared/ui/carousel/carousel.tsx
@@ -19,7 +19,7 @@ export function Carousel({ slidesPerView, children }: CarouselProps) {
   const { onPrevButtonClick, onNextButtonClick } = usePrevNextButtons(emblaApi);
 
   return (
-    <div className="grid gap-4 xl:grid-cols-[auto_1fr_auto]">
+    <div className="grid gap-[22px] xl:grid-cols-[auto_1fr_auto]">
       <CarouselButton
         className="hidden xl:inline"
         position="left"
@@ -33,7 +33,7 @@ export function Carousel({ slidesPerView, children }: CarouselProps) {
         </div>
       </div>
 
-      <div className="flex justify-between xl:hidden">
+      <div className="flex justify-between px-18 xl:hidden">
         <CarouselButton position="left" onClick={onPrevButtonClick} />
         <CarouselButton position="right" onClick={onNextButtonClick} />
       </div>


### PR DESCRIPTION
задача 

<img width="482" height="512" alt="Screenshot from 2025-11-06 21-57-35" src="https://github.com/user-attachments/assets/61ac7a73-7235-4a0b-83d2-d98045e4ddfc" />




1 добавил px-18  for mobile

<img width="572" height="168" alt="Screenshot from 2025-11-06 21-54-44" src="https://github.com/user-attachments/assets/2f51021c-b081-43f5-ae87-c10409d77640" />
