### PR TITLE
fix(shared,widgets): refined padding remove-offsets

### DIFF
--- a/src/shared/ui/carousel/carousel.tsx
+++ b/src/shared/ui/carousel/carousel.tsx
@@ -26,7 +26,7 @@ export function Carousel({ slidesPerView, children }: CarouselProps) {
         onClick={onPrevButtonClick}
       />
       <div ref={emblaRef} className="overflow-hidden">
-        <div className="flex gap-1">
+        <div className="flex">
           {Children.map(children, (child) => (
             <CarouselItem slidesPerView={slidesPerView}>{child}</CarouselItem>
           ))}

--- a/src/widgets/gallery/ui/gallery.tsx
+++ b/src/widgets/gallery/ui/gallery.tsx
@@ -4,7 +4,7 @@ import { GalleryCard } from "./gallery-сard";
 
 export function Gallery() {
   return (
-    <section className="flex flex-col items-center gap-6 px-5 py-10">
+    <section className="flex flex-col items-center gap-6 px-5 py-10 xl:px-20">
       <Title className="text-center">Галерея</Title>
       <Carousel slidesPerView={3}>
         {galleryData.map((item) => (


### PR DESCRIPTION
1 уточнил паддинги по дизайну 

<img width="1028" height="398" alt="Screenshot from 2025-11-12 11-31-55" src="https://github.com/user-attachments/assets/928c3c94-198a-4248-8e5f-69ff70e38ca9" />

2 сверил с макетом 

3 убрал офсет (смещение микро) на десктопе