### PR TITLE
fix(widgets): refind-coach-card

### DIFF
--- a/src/widgets/coaches/ui/coach-сard.tsx
+++ b/src/widgets/coaches/ui/coach-сard.tsx
@@ -5,12 +5,12 @@ type CoachCardProps = Coach;
 
 export function CoachCard({ name, description, src, alt }: CoachCardProps) {
   return (
-    <div className="flex flex-col items-center gap-5">
+    <div className="flex flex-col items-center">
       <div className="flex flex-col items-center overflow-hidden rounded-[18px] border-2 border-[oklch(0.8327_0.002_247.32)]">
         <div className="relative h-70 w-80">
           <Image src={src} alt={alt} sizes="320px" fill />
         </div>
-        <hgroup className="flex max-w-[268px] flex-col items-center gap-3">
+        <hgroup className="flex max-w-[268px] flex-col items-center gap-3 pt-4 pb-5">
           <h4 className="text-xl font-bold text-accent-orange">{name}</h4>
           <p className="text-center text-sm text-foreground-secondary">
             {description}


### PR DESCRIPTION
1 уточнил карточку тренера с дизайном 

<img width="422" height="506" alt="Screenshot from 2025-11-12 13-07-09" src="https://github.com/user-attachments/assets/ce8dbd54-b9d5-4c81-9570-594c39cf8f47" />
