### PR TITLE
fix(widgets): refind align owner

### DIFF
--- a/src/widgets/coaches/ui/owner.tsx
+++ b/src/widgets/coaches/ui/owner.tsx
@@ -5,7 +5,7 @@ export function Owner() {
   return (
     <div className="flex flex-col items-center xl:flex-row xl:justify-center xl:gap-14">
       <Image src={ownerData.src} width={314} height={407} alt={ownerData.alt} />
-      <div className="flex flex-col items-center gap-5 xl:justify-center">
+      <div className="flex flex-col items-center gap-5 xl:items-start xl:justify-center">
         <hgroup className="flex flex-col items-center gap-2.5 xl:items-start">
           {/* помню про заголвки в 32px, но он ломает верстку */}
           <h3 className="font-shantell text-[28px] font-bold text-foreground xl:text-[44px]">


### PR DESCRIPTION
task

<img width="631" height="719" alt="Screenshot from 2025-11-12 13-47-27" src="https://github.com/user-attachments/assets/7a5cc42f-81b6-4031-a494-69653c795da1" />



resolve

<img width="1057" height="367" alt="Screenshot from 2025-11-12 13-44-54" src="https://github.com/user-attachments/assets/824e519f-b247-437c-b547-466b64070379" />
