### PR TITLE
feat(widgets): add animations for border accordion

### DIFF
--- a/src/shared/ui/accordion.tsx
+++ b/src/shared/ui/accordion.tsx
@@ -24,7 +24,7 @@ export function Accordion({ items }: AccordionProps) {
           <div
             key={question}
             className={cn(
-              "cursor-pointer items-center justify-between rounded-xl border border-accent-orange-light px-6 text-sm xl:text-lg",
+              "cursor-pointer items-center justify-between rounded-xl border border-accent-orange-light px-6 text-sm transition-colors duration-600 xl:text-lg",
               {
                 "border-accent-orange": isOpen,
               },


### PR DESCRIPTION
<img width="294" height="108" alt="Screenshot from 2025-12-04 11-46-59" src="https://github.com/user-attachments/assets/9b942e48-9bde-4b65-9367-d6357f945202" />
<img width="604" height="236" alt="Screenshot from 2025-12-04 11-47-50" src="https://github.com/user-attachments/assets/8ca9c38a-78ad-4da1-9a99-7ddad509e794" />
