### PR TITLE
fix(widgets): gap between trainers checked, changed by 40px

### DIFF
--- a/src/widgets/coaches/ui/coaches.tsx
+++ b/src/widgets/coaches/ui/coaches.tsx
@@ -5,7 +5,7 @@ import { OwnerCard } from "./owner-card";
 
 export function Coaches() {
   return (
-    <section className="flex flex-col items-center gap-6 py-10 xl:px-20">
+    <section className="flex flex-col items-center gap-11 py-10 xl:gap-10 xl:px-20">
       <OwnerCard />
       <Carousel innerWrapperClassName="max-w-252" slidesPerView={3}>
         {coachesData.map((coach) => (


### PR DESCRIPTION

<img width="581" height="428" alt="Screenshot from 2025-12-04 16-08-39" src="https://github.com/user-attachments/assets/6ec4bdbe-d9d2-4951-8669-fb313c080e67" />

изменил на 40px как по дизайну