### PR TITLE
fix(widgets): install height for header 80px

### DIFF
--- a/src/widgets/header/ui/header.tsx
+++ b/src/widgets/header/ui/header.tsx
@@ -17,7 +17,7 @@ export async function Header() {
         "sticky top-0 z-20 bg-background/60 text-accent-orange shadow-[1px_2px_6px_0_oklch(0_0_0/0.12)] backdrop-blur-sm has-data-[menu-open='true']:bg-background has-data-[menu-open='true']:backdrop-blur-none",
       )}
     >
-      <Container className="flex items-center justify-between py-2 pr-12 pl-6 xl:px-20">
+      <Container className="flex items-center justify-between py-0.5 pr-12 pl-6 xl:px-20">
         <Link href={navLinks.home.href}>
           <Image
             src="/logo.svg"


### PR DESCRIPTION
<img width="650" height="54" alt="Screenshot from 2026-02-17 14-32-20" src="https://github.com/user-attachments/assets/2ff61080-b29f-4cd6-9bd0-0a7be5f21232" />

<img width="531" height="113" alt="Screenshot from 2026-02-17 14-40-32" src="https://github.com/user-attachments/assets/7530b7cb-f823-454c-9c15-ed16c8307bfe" />
