### PR TITLE
feat(app, shared): add component overlap

### DIFF
--- a/src/app/(frontend)/(main)/page.tsx
+++ b/src/app/(frontend)/(main)/page.tsx
@@ -1,4 +1,4 @@
-import { OverlapContainer } from "@/shared/ui/overlap-container";
+import { ContainerWithShadow } from "@/shared/ui/container-with-shadow";
 import {
   Hero,
   Advantages,
@@ -19,16 +19,16 @@ export default function Home() {
   return (
     <div>
       <Hero />
-      <OverlapContainer>
+      <ContainerWithShadow>
         <Advantages />
+        <Coaches />
         <Locations />
         <SignUpForWorkout />
-        <Coaches />
-      </OverlapContainer>
+        <Gallery />
+      </ContainerWithShadow>
       <Faq />
       <GiftCertificates />
       <Banner />
-      <Gallery />
     </div>
   );
 }

--- a/src/app/(frontend)/(main)/page.tsx
+++ b/src/app/(frontend)/(main)/page.tsx
@@ -1,3 +1,4 @@
+import { OverlapContainer } from "@/shared/ui/overlap-container";
 import {
   Hero,
   Advantages,
@@ -18,10 +19,12 @@ export default function Home() {
   return (
     <div>
       <Hero />
-      <Advantages />
-      <Locations />
-      <SignUpForWorkout />
-      <Coaches />
+      <OverlapContainer>
+        <Advantages />
+        <Locations />
+        <SignUpForWorkout />
+        <Coaches />
+      </OverlapContainer>
       <Faq />
       <GiftCertificates />
       <Banner />

--- a/src/shared/ui/container-with-shadow.tsx
+++ b/src/shared/ui/container-with-shadow.tsx
@@ -1,6 +1,6 @@
-type NativeDivProps = Pick<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children">;
+type ContainerWithShadowProps = React.PropsWithChildren;
 
-export function OverlapContainer({ children }: NativeDivProps) {
+export function ContainerWithShadow({ children }: ContainerWithShadowProps) {
   return (
     <div className="flex flex-col rounded-[42px] shadow-[0_-20px_30px_0_oklch(0%_0_0/0.1),0_20px_30px_0_oklch(0%_0_0/0.1)]">
       {children}

--- a/src/shared/ui/overlap-container.tsx
+++ b/src/shared/ui/overlap-container.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/shared/lib";
+
+type NativeDivProps = Pick<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children">;
+
+export function OverlapContainer({ children }: NativeDivProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col rounded-[42px] shadow-[0_-20px_30px_0_oklch(0%_0_0/0.1),0_20px_30px_0_oklch(0%_0_0/0.1)]",
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/shared/ui/overlap-container.tsx
+++ b/src/shared/ui/overlap-container.tsx
@@ -1,14 +1,8 @@
-import { cn } from "@/shared/lib";
-
 type NativeDivProps = Pick<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children">;
 
 export function OverlapContainer({ children }: NativeDivProps) {
   return (
-    <div
-      className={cn(
-        "flex flex-col rounded-[42px] shadow-[0_-20px_30px_0_oklch(0%_0_0/0.1),0_20px_30px_0_oklch(0%_0_0/0.1)]",
-      )}
-    >
+    <div className="flex flex-col rounded-[42px] shadow-[0_-20px_30px_0_oklch(0%_0_0/0.1),0_20px_30px_0_oklch(0%_0_0/0.1)]">
       {children}
     </div>
   );


### PR DESCRIPTION
<img width="833" height="917" alt="Screenshot from 2026-05-13 16-48-36" src="https://github.com/user-attachments/assets/85dc407f-10c6-4d95-9c8c-94362a1f6ccb" />
