### PR TITLE
fix(widgets): displaying the footer at a width of 425 px

### DIFF
--- a/src/widgets/footer/ui/footer-nav.tsx
+++ b/src/widgets/footer/ui/footer-nav.tsx
@@ -27,7 +27,7 @@ export function FooterNav() {
       <div className="flex flex-col items-center gap-4.5 text-[18px] md:items-start md:gap-7">
         <h2 className="text-sm">Документы</h2>
         <ul className="flex flex-col items-center gap-4.5 font-bold uppercase md:items-start">
-          <li className="text-center md:text-left">
+          <li className="max-w-80 text-center md:text-left">
             <Link href={navLinks.policy.href}>{navLinks.policy.title}</Link>
           </li>
           <li>


### PR DESCRIPTION
**Стало**:

<img width="480" height="270" alt="Screenshot from 2026-05-31 07-33-03" src="https://github.com/user-attachments/assets/5391734c-546d-489d-bedc-4d21e09b5da7" />


**было:**

<img width="526" height="172" alt="Screenshot from 2026-05-31 07-36-42" src="https://github.com/user-attachments/assets/deac5a58-fbe3-4481-a84d-45e6081ba066" />

Дизайн : 

<img width="402" height="96" alt="Screenshot from 2026-05-31 07-38-01" src="https://github.com/user-attachments/assets/5a0964b1-334a-4110-9e71-0e198d258c37" />

