### PR TITLE
feat(shared, entities): added display reading time correctly

### DIFF
--- a/src/entities/blog/date-with-read-time.tsx
+++ b/src/entities/blog/date-with-read-time.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { formatReadingTime } from "@/shared/lib";
 import { format } from "date-fns";
 import { ru } from "date-fns/locale";
 
@@ -17,7 +18,7 @@ export function DateWithReadTime({ date, readTime }: DateWithReadTimeProps) {
           height={16}
           alt="Символ глаза - колличество просмотров"
         />
-        <span>{readTime} минут</span>
+        <span>{formatReadingTime(readTime)}</span>
       </div>
     </div>
   );

--- a/src/shared/lib/format-reading-time.ts
+++ b/src/shared/lib/format-reading-time.ts
@@ -1,0 +1,14 @@
+export const formatReadingTime = (minutes: number) => {
+  const pluralRule = new Intl.PluralRules("ru-RU");
+  const key = pluralRule.select(minutes);
+  const forms: Record<Intl.LDMLPluralRule, string> = {
+    one: "минута",
+    two: "минуты",
+    few: "минуты",
+    many: "минут",
+    other: "минуты",
+    zero: "минут",
+  };
+
+  return `${minutes} ${forms[key]}`;
+};

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,6 +1,7 @@
 export { cn } from "./cn";
 export { getPhoneHref } from "./get-phone-href";
 export { formatPhone } from "./format-phone";
+export { formatReadingTime } from "./format-reading-time";
 export { strJoiner } from "./str-joiner";
 export { getBounds } from "./get-bounds";
 export { MapContext, useMapContext } from "./contexts";


### PR DESCRIPTION
<img width="563" height="372" alt="image" src="https://github.com/user-attachments/assets/08f58320-a21a-4556-8cf5-d1a703daa15a" />
